### PR TITLE
fix: AI dashboard shows wrong command suggestions

### DIFF
--- a/scripts/agent-daily-ai-workflow.sh
+++ b/scripts/agent-daily-ai-workflow.sh
@@ -182,7 +182,7 @@ show_ai_dashboard() {
     echo "  just ai-review              - Get AI code review"
     echo "  just learn                  - Learn from patterns"
     echo "  just mlops-artifact         - Generate MLOps proof artifact"
-    echo "  just job-apply              - Track job application"
+    echo "  just job-apply <company> <role> - Track job application"
     echo "  just proof-pack             - Generate proof pack items"
     
     echo "═══════════════════════════════════════════════════════"
@@ -219,16 +219,16 @@ suggest_next_actions() {
     # Service-specific suggestions
     case "$AGENT_ID" in
         a1)
-            echo "  • Check performance metrics with 'just mlops-metrics'"
+            echo "  • Check performance metrics with 'just real-metrics'"
             ;;
         a2)
-            echo "  • Analyze token usage with 'just token-optimize'"
+            echo "  • Analyze token usage with 'just ai-token-optimize'"
             ;;
         a3)
-            echo "  • Update portfolio with 'just update-achievements'"
+            echo "  • Generate documentation with 'just ai-docs'"
             ;;
         a4)
-            echo "  • Check revenue metrics with 'just revenue-report'"
+            echo "  • Check A/B test results with 'just ab-results'"
             ;;
     esac
 }


### PR DESCRIPTION
## Problem
The ai-dashboard was suggesting non-existent commands, causing confusion for agents trying to use them.

## Solution
Fixed the hardcoded suggestions in `agent-daily-ai-workflow.sh` to use actual existing commands.

## Changes
- `just mlops-metrics` → `just real-metrics` (actual command that exists)
- `just token-optimize` → `just ai-token-optimize` (correct command name)
- `just update-achievements` → `just ai-docs` (existing command)
- `just revenue-report` → `just ab-results` (existing command)
- `just job-apply` → `just job-apply <company> <role>` (show required params)

## Testing
All suggested commands now actually exist and work:
```bash
just real-metrics     # ✅ Works
just ai-token-optimize # ✅ Works  
just ai-docs          # ✅ Works
just ab-results       # ✅ Works
```

## Note on .agent.env files
The worktrees already have properly configured `.agent.env` files with all necessary variables:
- AGENT_ID, AGENT_SERVICES, FOCUS_AREAS
- PORT_OFFSET for avoiding conflicts
- DB_SCHEMA for database isolation
- JOB_PRIORITY and PORTFOLIO_FOCUS for job search

No additional setup needed - agents can use commands immediately after rebasing.

## Impact
- Agents won't get confused trying to run non-existent commands
- Dashboard suggestions now match actual available commands
- Better developer experience for all 4 parallel agents